### PR TITLE
Allow authentication headers

### DIFF
--- a/broker/handlers/base-router.go
+++ b/broker/handlers/base-router.go
@@ -23,8 +23,15 @@ type Router struct {
 func NewRouter(configuration *services.Configuration, jwtService *services.JwtService, repository *repository.RepositoryStrategy) *Router {
 	gin.SetMode(gin.ReleaseMode)
 	engine := gin.New()
+	corsSettings := cors.New(cors.Config{
+		AllowAllOrigins:  true,
+		AllowMethods:     []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"},
+		AllowHeaders:     []string{"Origin", "Content-Type", "Authorization", "Access-Control-Request-Headers"},
+		ExposeHeaders:    []string{"Content-Length"},
+		AllowCredentials: true,
+	})
 
-	engine.Use(cors.Default())
+	engine.Use(corsSettings)
 	engine.Use(gin.Recovery())
 	engine.Use(middleware.RequestLogging())
 

--- a/broker/handlers/handler-auth.go
+++ b/broker/handlers/handler-auth.go
@@ -61,6 +61,7 @@ func (handler *AuthHandler) login(jwtService *services.JwtService) gin.HandlerFu
 
 // The logout handler processes user logout requests.
 // It invalidates the provided JWT token by setting it as revoked in the repository.
+// The handler returns a JSON object with a result field indicating success or failure.
 func (handler *AuthHandler) logout() gin.HandlerFunc {
 	return func(context *gin.Context) {
 		authHeader := context.GetHeader("Authorization")
@@ -68,10 +69,10 @@ func (handler *AuthHandler) logout() gin.HandlerFunc {
 
 		status := handler.repository.JwtRepository.Delete(token)
 		if !status {
-			context.JSON(400, gin.H{"error": "Logout failed"})
+			context.JSON(400, gin.H{"result": false})
 			return
 		}
 
-		context.JSON(200, gin.H{"message": "Logout successful"})
+		context.JSON(200, gin.H{"result": true})
 	}
 }


### PR DESCRIPTION
# Authentication headers

The front-end currently sends the authorization through the `Access-Control-Request-Header`. This header has been added to the CORS configuration. The response of the logout has also been changed to a boolean for simplicity.