### PR TITLE
Gebruikersrollen toegevoegd in autorisatie 

### DIFF
--- a/broker/domain/user.go
+++ b/broker/domain/user.go
@@ -18,3 +18,22 @@ type User struct {
 func (user *User) ValidatePassword(password string) bool {
 	return bcrypt.CompareHashAndPassword([]byte(user.PasswordHash), []byte(password)) == nil
 }
+
+// Check whether the user has a specific role.
+// Valid options are "", "user" and "admin".
+// "admin" role includes "user" privileges.
+func (user *User) HasRole(role string) bool {
+	if role == "" {
+		return true
+	}
+
+	if role == "user" {
+		return user.Role == "user" || user.Role == "admin"
+	}
+
+	if role == "admin" {
+		return user.Role == "admin"
+	}
+
+	return false
+}

--- a/broker/handlers/handler-auth.go
+++ b/broker/handlers/handler-auth.go
@@ -54,6 +54,7 @@ func (handler *AuthHandler) login(jwtService *services.JwtService) gin.HandlerFu
 		handler.repository.JwtRepository.Add(token, user.Id, time)
 		context.JSON(200, gin.H{
 			"token":      token,
+			"role":       user.Role,
 			"expires_at": time,
 		})
 	}

--- a/broker/middleware/jwt.go
+++ b/broker/middleware/jwt.go
@@ -12,10 +12,18 @@ import (
 // JwtMiddleware extracts and verifies the JWT token from the Authorization header of the HTTP request
 // It returns the subject from the token claims if verification is successful.
 // When authorization fails, it logs the reason and returns an empty string.
-// Based on the 'required' flag, it either aborts the request with 401 or allows it to proceed.
+// The 'minimal role' parameter can be used to enforce role-based access control.
+// Valid roles are "" for optional, "user" for all users and "admin" for administrators only.
 // Possible reasons are: missing header, invalid format, or token verification failure.
-func JwtMiddleware(jwtService *services.JwtService, repository *repository.RepositoryStrategy, required bool) gin.HandlerFunc {
+func JwtMiddleware(jwtService *services.JwtService, repository *repository.RepositoryStrategy, minimalRole string) gin.HandlerFunc {
 	return func(context *gin.Context) {
+		required := minimalRole != ""
+		if minimalRole != "" && minimalRole != "user" && minimalRole != "admin" {
+			log.Println("[JWT] Invalid minimal role specified in middleware")
+			context.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "Server configuration error"})
+			return
+		}
+
 		header := context.GetHeader("Authorization")
 		if header == "" {
 			authenticationError(context, "Authorization header missing", required)
@@ -40,6 +48,17 @@ func JwtMiddleware(jwtService *services.JwtService, repository *repository.Repos
 			return
 		}
 
+		user := repository.UserRepository.Get(claims.Subject)
+		if user == nil {
+			authenticationError(context, "User not found", required)
+			return
+		}
+
+		if !user.HasRole(minimalRole) {
+			authenticationError(context, "Insufficient user role", required)
+			return
+		}
+
 		context.Set("user_id", claims.Subject)
 		context.Set("authenticated", true)
 		context.Next()
@@ -54,7 +73,7 @@ func authenticationError(context *gin.Context, message string, required bool) {
 	log.Println("[JWT] " + message)
 
 	if required {
-		context.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "message"})
+		context.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "User account error: " + message})
 	} else {
 		context.Next()
 	}

--- a/readme.md
+++ b/readme.md
@@ -58,6 +58,7 @@ The response will look something like:
 ```json
 {
     "expires_at": "2025-11-26T12:44:37.583752433Z",
+    "role": "admin",
     "token": "very.long.jwt.token.here"
 }
 ```


### PR DESCRIPTION
Tijdens het aanmaken van gebruikers in #13 is het essentieel dat enkel administrators dit kunnen. Dit is een bug gezien het systeem hier al mee overweg zou moeten kunnen. Deze pull-request voegt deze mogelijkheid daadwerkelijk toe.

## Rollen voor de achterkant

Er is een wijziging doorgevoerd in het maken van een route. Zo is de required flag in `middleware/jwt.go` vervangen door een minimale rol. Deze rol kan worden ingesteld door middel van een string, zijnde `""` voor optioneel, `"user"` voor alle gebruikers en `"admin"` voor enkel administrators. De check vind plaats in `domain/user`.

## Rollen voor de Frontend

De front-end is niet genegeerd tijdens het implementeren van deze functionaliteit. De rol wordt meegegeven tijdens het inloggen van de gebruiker zodat deze kan worden gebruikt in de front-end hoe deze dat zou willen. Het complete antwoord is nu:

```json
{
    "expires_at": "2025-11-26T12:44:37.583752433Z",
    "role": "admin",
    "token": "very.long.jwt.token.here"
}
```