### PR TITLE
Added initialization to the back-end

### DIFF
--- a/broker/handlers/base-router.go
+++ b/broker/handlers/base-router.go
@@ -38,6 +38,7 @@ func NewRouter(configuration *services.Configuration, jwtService *services.JwtSe
 	NewStatusHandler(repository).RegisterRoutes(engine, jwtService)
 	NewAuthHandler(repository).RegisterRoutes(engine, jwtService)
 	NewUserHandler(repository).RegisterRoutes(engine, jwtService)
+	NewInitializationHandler(repository).RegisterRoutes(engine, jwtService)
 
 	return &Router{
 		engine: engine,

--- a/broker/handlers/handler-initialization.go
+++ b/broker/handlers/handler-initialization.go
@@ -1,0 +1,87 @@
+package handlers
+
+import (
+	"hotelhub/broker/domain"
+	"hotelhub/broker/repository"
+	"hotelhub/broker/services"
+
+	"github.com/gin-gonic/gin"
+	"golang.org/x/crypto/bcrypt"
+)
+
+// InitializationHandler is used to handle a status check, implementing the BaseHandler interface.
+// It requires a RepositoryStrategy to access the data layer if needed.
+type InitializationHandler struct {
+	repository *repository.RepositoryStrategy
+}
+
+// NewInitializationHandler creates a new instance of StatusHandler.
+// It takes a RepositoryStrategy as a parameter to access the data layer if needed.
+func NewInitializationHandler(repository *repository.RepositoryStrategy) BaseHandler {
+	return &InitializationHandler{
+		repository: repository,
+	}
+}
+
+// RegisterRoutes registers the status check route with the provided Gin engine.
+func (handler *InitializationHandler) RegisterRoutes(engine *gin.Engine, jwt *services.JwtService) {
+	engine.POST("/initialize", handler.Initialize(jwt))
+}
+
+// The initialize method handles the system initialization process.
+// It checks if the system is already initialized, and will fail if so.
+// If not initialized, it creates an admin user and sets the necessary metadata.
+func (handler *InitializationHandler) Initialize(jwtService *services.JwtService) gin.HandlerFunc {
+	type InitializationRequest struct {
+		HotelName     string `json:"hotel_name" binding:"required"`
+		AdminEmail    string `json:"admin_email" binding:"required,email"`
+		AdminPassword string `json:"admin_password" binding:"required,min=8"`
+		AdminName     string `json:"admin_name" binding:"required"`
+	}
+
+	return func(context *gin.Context) {
+		initialized := handler.repository.MetaRepository.Get("initialized")
+		if initialized != "" {
+			context.JSON(400, gin.H{"error": "System is already initialized"})
+			return
+		}
+
+		var request InitializationRequest
+		if err := context.ShouldBindJSON(&request); err != nil {
+			context.JSON(400, gin.H{"error": err.Error()})
+			return
+		}
+
+		password, err := bcrypt.GenerateFromPassword([]byte(request.AdminPassword), bcrypt.DefaultCost)
+		if err != nil {
+			context.JSON(500, gin.H{"error": "Failed to hash password"})
+			return
+		}
+
+		user := domain.User{
+			Email:        request.AdminEmail,
+			PasswordHash: string(password),
+			Name:         request.AdminName,
+			Role:         "admin",
+			Enabled:      true,
+		}
+
+		createdUser := handler.repository.UserRepository.Create(&user)
+		createdUser = handler.repository.UserRepository.Update(user.Email, user.PasswordHash)
+		if createdUser == nil {
+			context.JSON(500, gin.H{"error": "Failed to create admin user"})
+			return
+		}
+
+		handler.repository.MetaRepository.Set("hotel", request.HotelName)
+		handler.repository.MetaRepository.Set("initialized", "true")
+		token, time := jwtService.GenerateToken(user.Email)
+		handler.repository.JwtRepository.Add(token, user.Email, time)
+
+		context.JSON(200, gin.H{
+			"token":      token,
+			"role":       user.Role,
+			"expires_at": time,
+		})
+	}
+}

--- a/broker/repository/base-meta.go
+++ b/broker/repository/base-meta.go
@@ -1,0 +1,9 @@
+package repository
+
+// The base for the meta repository takes care of getting and setting information in the meta repository.
+// Gettings returns the value of the key as string, setting returns the name of the key set.
+// On error, both return an empty string.
+type BaseMetaRepository interface {
+	Get(key string) string
+	Set(key string, value string) string
+}

--- a/broker/repository/base-repository-strategy.go
+++ b/broker/repository/base-repository-strategy.go
@@ -9,6 +9,7 @@ type RepositoryStrategy struct {
 	JwtRepository    BaseJwtRepository
 	PluginRepository PluginRepository
 	UserRepository   BaseUserRepository
+	MetaRepository   BaseMetaRepository
 }
 
 // NewPostgresRepositoryStrategy creates a new RepositoryStrategy using Postgres repositories.
@@ -17,5 +18,6 @@ func NewPostgresRepositoryStrategy(postgres *services.Postgres) *RepositoryStrat
 	return &RepositoryStrategy{
 		UserRepository: NewPostgresUserRepository(postgres),
 		JwtRepository:  NewPostgresJwtRepository(postgres),
+		MetaRepository: NewPostgresMetaRepository(postgres),
 	}
 }

--- a/broker/repository/postgres-meta.go
+++ b/broker/repository/postgres-meta.go
@@ -1,0 +1,59 @@
+package repository
+
+import (
+	"database/sql"
+	"hotelhub/broker/services"
+	"log"
+)
+
+// PostgresMetaRepository is a Postgres implementation of the BaseMetaRepository interface.
+// It requires an instance of the Postgres service to interact with the database.
+type PostgresMetaRepository struct {
+	database *services.Postgres
+}
+
+// NewPostgresMetaRepository creates a new instance of PostgresMetaRepository.
+func NewPostgresMetaRepository(database *services.Postgres) BaseMetaRepository {
+	return &PostgresMetaRepository{
+		database: database,
+	}
+}
+
+// Get retrieves the value for the provided key from the meta table.
+// Returns an empty string on error or if the key does not exist.
+func (repo *PostgresMetaRepository) Get(key string) string {
+	var value sql.NullString
+	query := "SELECT value FROM meta WHERE key = $1"
+
+	row := repo.database.QueryRow(query, key)
+	if row == nil {
+		log.Println("[Postgres] Cannot retrieve meta key:", key)
+		return ""
+	}
+
+	err := row.Scan(&value)
+	if err != nil {
+		log.Println("[Postgres] Error scanning meta row:", err)
+		return ""
+	}
+
+	return value.String
+}
+
+// Set updates the value for the provided key if it exists, otherwise inserts a new row.
+// Returns the key on success and an empty string on failure.
+func (repo *PostgresMetaRepository) Set(key string, val string) string {
+	updateQuery := "UPDATE meta SET value = $1 WHERE key = $2"
+	rows := repo.database.Execute(updateQuery, val, key)
+
+	if rows == 0 {
+		insertQuery := "INSERT INTO meta (key, value) VALUES ($1, $2)"
+		rows = repo.database.Execute(insertQuery, key, val)
+		if rows == 0 {
+			log.Println("[Postgres] Cannot set meta key:", key)
+			return ""
+		}
+	}
+
+	return key
+}

--- a/migrations/000_create_db_and_meta_table.sql
+++ b/migrations/000_create_db_and_meta_table.sql
@@ -3,6 +3,3 @@ CREATE TABLE IF NOT EXISTS meta (
     key TEXT PRIMARY KEY,
     value TEXT
 );
-
--- Insert initial metadata
-INSERT INTO meta (key, value) VALUES ('initialized', '');

--- a/migrations/000_create_db_and_meta_table.sql
+++ b/migrations/000_create_db_and_meta_table.sql
@@ -1,8 +1,8 @@
 -- The Meta table stores key-value pairs for application metadata.
 CREATE TABLE IF NOT EXISTS meta (
     key TEXT PRIMARY KEY,
-    value TEXT NOT NULL
+    value TEXT
 );
 
 -- Insert initial metadata
-INSERT INTO meta (key, value) VALUES ('name', 'HotelHub');
+INSERT INTO meta (key, value) VALUES ('initialized', '');

--- a/readme.md
+++ b/readme.md
@@ -51,6 +51,28 @@ The default login credentials are: `admin@admin.com` and password `admin`.
 From this point, a new server connection can be created to connect to the Postgres database.
 
 
+
+## Initialization
+
+The backend requires some initial setup before it can be used. 
+This can be achieved by sending a POST request to the `/initialize` endpoint.
+This endpoint sets up the initial administrator user and configures basic information.
+An example request body for initialization is as follows:
+
+```json
+{
+    "hotel_name": "Superior Hotel",
+    "admin_name": "Admin McAdminface",
+    "admin_email": "admin@superior-hotel.net",
+    "admin_password": "strong_password_123"
+}
+```
+
+A successful initialization will return a 200 status code.
+It will also login the newly created administrator user and provide a JWT token in the response body.
+See the Authentication section for more information on how the token is returned.
+
+
 ## Authentication and User Management
 
 The backend provides endpoints for authentication and user management.


### PR DESCRIPTION
# Back-end Initialization

The back-end needs to be initialized in order to function properly.
This involves setting up necessary meta data for the hotel, and the initial administrator account.
The route to call is `/initialize`, which will perform the setup based on the following information:

```json
{
  "hotel_name": "string",
  "admin_email": "string",
  "admin_password": "string"
  "admin_name": "string"
}
```

If initialization is successful, the response will contain a JWT token for the administrator account.
This way, the admin can immediately start using the system after setup.
Existing functionality regarding the token generation has been used to create the token for the admin user.
Which includes the response structure and token expiration settings.
